### PR TITLE
Update array initialization syntax to use the C++11 standard

### DIFF
--- a/test/test_executor.cpp
+++ b/test/test_executor.cpp
@@ -110,24 +110,24 @@ struct Serializer {
     // Values: a, b, x, y and intermediate z (ax), all tensors
     // Constant tensors a and b have data.
     std::vector<EValue> values;
-    auto a_sizes = new int[]{2, 2};
+    auto a_sizes = new int[2]{2, 2};
     int a_data[4]{1, 2, 3, 4};
     Tensor a(ScalarType::Int, 2, a_sizes, a_data);
     values.emplace_back(&a);
 
-    auto b_sizes = new int[]{2, 2};
+    auto b_sizes = new int[2]{2, 2};
     int b_data[4]{5, 6, 7, 8};
     Tensor b(ScalarType::Int, 2, b_sizes, b_data);
     values.emplace_back(&b);
 
     // Rest of tensors (x, z, y) don't have data
-    auto x_sizes = new int[]{2, 2};
+    auto x_sizes = new int[2]{2, 2};
     Tensor x(ScalarType::Int, 2, x_sizes);
 
-    auto y_sizes = new int[]{2, 2};
+    auto y_sizes = new int[2]{2, 2};
     Tensor y(ScalarType::Int, 2, y_sizes);
 
-    auto z_sizes = new int[]{2, 2};
+    auto z_sizes = new int[2]{2, 2};
     Tensor z(ScalarType::Int, 2, z_sizes);
 
     values.emplace_back(&x);
@@ -212,7 +212,7 @@ struct Serializer {
 };
 
 TEST(ExecutorTest, Tensor) {
-  auto sizes = new int[]{2, 2};
+  auto sizes = new int[2]{2, 2};
   int data[4]{1, 2, 3, 4};
   Tensor a(ScalarType::Int, 2, sizes, data);
 
@@ -224,7 +224,7 @@ TEST(ExecutorTest, Tensor) {
 }
 
 TEST(ExecutorTest, EValue) {
-  auto sizes = new int[]{2, 2};
+  auto sizes = new int[2]{2, 2};
   int data[4]{1, 2, 3, 4};
   Tensor a(ScalarType::Int, 2, sizes, data);
 
@@ -285,17 +285,17 @@ TEST(ExecutorTest, Registry) {
 
   EValue* values = new EValue[3];
 
-  auto a_sizes = new int[]{2, 2};
+  auto a_sizes = new int[2]{2, 2};
   int a_data[4]{1, 2, 3, 4};
   Tensor a(ScalarType::Int, 2, a_sizes, a_data);
   values[0] = EValue(&a);
 
-  auto b_sizes = new int[]{2, 2};
+  auto b_sizes = new int[2]{2, 2};
   int b_data[4]{5, 6, 7, 8};
   Tensor b(ScalarType::Int, 2, b_sizes, b_data);
   values[1] = EValue(&b);
 
-  auto c_sizes = new int[]{2, 2};
+  auto c_sizes = new int[2]{2, 2};
   int c_data[4]{0, 0, 0, 0};
   Tensor c(ScalarType::Int, 2, c_sizes, c_data);
   values[2] = EValue(&c);


### PR DESCRIPTION
Currently, unit tests use a syntax style added in C++20; namely, that an unknown bound type `U[]` can be used in list initialization. (https://en.cppreference.com/w/cpp/language/list_initialization).

This change updates the array initialization syntax used in the unit tests to use the C++11 standard.