### PR TITLE
Add support for Scalar type in EValue

### DIFF
--- a/core/Evalue.h
+++ b/core/Evalue.h
@@ -82,27 +82,40 @@ struct EValue {
         return payload.as_bool;
     }
 
-    // TODO Support Scalar. Need implict constructors from scalar before we can support in EValue
-    // The plan will be to convert out of scalar upon EValue creation and let the implicit constuctor
-    // handle toScalar().
-    // EValue(Scalar s) {
-    //     <set tag and correct union value based on dtype of s>
-    // }
+    /// Construct an EValue using the implicit value of a Scalar.
+    EValue(Scalar s) {
+        if (s.isInt()) {
+            tag = Tag::Int;
+            payload.as_int = s.toInt();
+        }
+        else if (s.isDouble()) {
+            tag = Tag::Double;
+            payload.as_double = s.toDouble();
+        }
+        else if (s.isBool()) {
+            tag = Tag::Bool;
+            payload.as_bool = s.toBool();
+        } else {
+            error_with_message("Scalar passed to EValue is not initialized.");
+        }
+    }
 
-    // bool isScalar() const {
-    //     return tag == Tag::Bool || tag == Tag::Double || tag == Tag::Int;
-    // }
+    bool isScalar() const {
+        return tag == Tag::Int || tag == Tag::Double || tag == Tag::Bool;
+    }
 
-    // Scalar toScalar() const {
-    //     if (isDouble())
-    //         return toDouble();
-    //     else if (isInt())
-    //         return toInt();
-    //     else if (isBool())
-    //         return toBool();
-    //     else
-    //         error_with_message("EValue is not a Scalar.");
-    // }
+    Scalar toScalar() const {
+        // Convert from implicit value to Scalar using implicit constructors.
+
+        if (isDouble())
+            return toDouble();
+        else if (isInt())
+            return toInt();
+        else if (isBool())
+            return toBool();
+        else
+            error_with_message("EValue is not a Scalar.");
+    }
 
     EValue(Tensor* t) : tag(Tag::Tensor) {
         payload.as_tensor = t;

--- a/test/test_executor.cpp
+++ b/test/test_executor.cpp
@@ -233,6 +233,36 @@ TEST(ExecutorTest, EValue) {
   ASSERT_EQ(v.toTensor()->nbytes, 16);
 }
 
+TEST(ExecutorTest, EValueFromScalar) {
+  Scalar b((bool)true);
+  Scalar i((int64_t)2);
+  Scalar d((double)3.0);
+
+  EValue evalue_b(b);
+  ASSERT_TRUE(evalue_b.isScalar());
+  ASSERT_TRUE(evalue_b.isBool());
+  ASSERT_EQ(evalue_b.toBool(), true);
+
+  EValue evalue_i(i);
+  ASSERT_TRUE(evalue_i.isScalar());
+  ASSERT_TRUE(evalue_i.isInt());
+  ASSERT_EQ(evalue_i.toInt(), 2);
+
+  EValue evalue_d(d);
+  ASSERT_TRUE(evalue_d.isScalar());
+  ASSERT_TRUE(evalue_d.isDouble());
+  ASSERT_NEAR(evalue_d.toDouble(), 3.0, 0.01);
+}
+
+TEST(ExecutorTest, EValueToScalar) {
+  EValue v((int64_t)2);
+  ASSERT_TRUE(v.isScalar());
+
+  Scalar s = v.toScalar();
+  ASSERT_TRUE(s.isInt());
+  ASSERT_EQ(s.toInt(), 2);
+}
+
 TEST(ExecutorTest, Serialize) {
   flatbuffers::FlatBufferBuilder fbb;
   Serializer serializer;


### PR DESCRIPTION
This change:
 - Add support for Scalar type in EValue
 - Add unit tests for conversions between EValue and Scalar