### PR TITLE
Add container meta data for output

### DIFF
--- a/schema/schema.fbs
+++ b/schema/schema.fbs
@@ -12,6 +12,12 @@ table Buffer {
   data:[ubyte] (force_align: 16);
 }
 
+// Table that contains the metadata about how
+// to unflatten the flattened output from compiler
+table OutputContainerMetadata {
+  encoded_str:string;
+}
+
 table QuantizedSchema {
   qscheme:byte;
   scale:double;


### PR DESCRIPTION
This field will be used in runtime to figure out how to construct the return type properly