### PR TITLE
Clean up Linux/C++11 warnings and errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,14 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+# To stay compatible with as many cross-compilation toolchains as possible,
+# the executor runtime must build with C++11, and without any compiler-specific
+# extensions.
+# TODO: We could move this restriction to the executor instead of applying it
+# globally.
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/codegen/Codegen.cmake
+++ b/codegen/Codegen.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 file(GLOB_RECURSE sources_templates "${CMAKE_CURRENT_LIST_DIR}/../kernels/templates/*.cpp")
 file(GLOB_RECURSE headers_templates "${CMAKE_CURRENT_LIST_DIR}/../kernels/templates/*.h")

--- a/core/ArrayRef.h
+++ b/core/ArrayRef.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <array>
+#include <cassert>
 #include <iterator>
 #include <vector>
 
@@ -64,15 +65,11 @@ class ArrayRef final {
 
   /// Construct an ArrayRef from a pointer and length.
   constexpr ArrayRef(const T* data, size_t length)
-      : Data(data), Length(length) {
-    assert(Data != nullptr || Length == 0);
-  }
+      : Data(data), Length(length) {}
 
   /// Construct an ArrayRef from a range.
    ArrayRef(const T* begin, const T* end)
-      : Data(begin), Length(end - begin) {
-    assert(Data != nullptr || Length == 0);
-  }
+      : Data(begin), Length(end - begin) {}
 
 
   /// Construct an ArrayRef from a std::vector.

--- a/core/error_message.cpp
+++ b/core/error_message.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdexcept>
@@ -7,7 +6,7 @@ namespace torch {
 namespace executor {
 
 // TODO: move to error handler
-void error_with_message(char* message) {
+void error_with_message(const char* message) {
   // A hacky error function before we have a good convention,
   // better without exception.
   printf("%s\n", message);

--- a/core/error_message.h
+++ b/core/error_message.h
@@ -4,8 +4,7 @@ namespace torch {
 namespace executor {
 
 // TODO: move to error handler
-void error_with_message(char* message);
+[[noreturn]] void error_with_message(const char* message);
 
 } // namespace executor
 } // namespace torch
-

--- a/test/test_executor.cpp
+++ b/test/test_executor.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include <core/Tensor.h>
+#include <core/tensor.h>
 #include <core/ArrayRef.h>
 #include <core/Evalue.h>
 #include <core/Scalar.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #42
* #41
* __->__ #40

Summary:
Clean up warnings and errors when building for C++11 under Linux using
clang 12.0.x and gcc 8.5.0.

- CMakeLists.txt/Codegen.cmake: Disable C++ extensions to avoid leaning
  on non-standard features
- ArrayRef.h: Include <cassert> for its call to `assert()`
- ArrayRef.h: Remove calls to `assert()` from constexpr methods, which
  is not supported in C++11
- error_message.cpp: .cpp file shouldn't have a `#pragma once`
- error_message.h/cpp: Make the parameter `const char*` so string
  literals can be used safely
- error_message.h: Annotate the function with `[[noreturn]]` to silence
  warnings
- test/test_executor.cpp: s/Tensor.h/tensor.h/; macOS's case-insensitive
  filesystem strikes again

Test Plan:

```
mkdir cmake-build
cd cmake-build
CC=`which clang` CXX=`which clang++` cmake ..
make

...

Built target executorch
```