### PR TITLE
Build codegen with -fPIC to fix linking on Linux

### DIFF
--- a/codegen/Codegen.cmake
+++ b/codegen/Codegen.cmake
@@ -85,4 +85,10 @@ add_library(GEN_TARGET STATIC
         ${generated_headers} ${ops_generated_headers}
         ${generated_sources} ${ops_generated_sources})
 
+# Linking this .a into libexecutorch.so on Linux requires -fPIC to be set
+# so that its symbols can be relocated. Unfortunately, at this point,
+# CMAKE_SYSTEM_NAME isn't set because project() hasn't been called yet, so do
+# this for all target OSes.
+set_property(TARGET GEN_TARGET PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(GEN_TARGET PUBLIC ${CMAKE_BINARY_DIR}/generated ${CMAKE_CURRENT_LIST_DIR}/../core)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #42
* __->__ #41
* #40

Summary:
Without this, linking fails on Linux with an error like:

```
ld: error: can't create dynamic relocation R_X86_64_32 against local symbol in readonly segment; recompile object files with -fPIC or pass '-Wl,-z,notext' to allow text relocations in the output
>>> defined in libGEN_TARGET.a(RegisterCodegenUnboxedKernels_0.cpp.o)
>>> referenced by RegisterCodegenUnboxedKernels_0.cpp
>>>               RegisterCodegenUnboxedKernels_0.cpp.o:(.eh_frame+0x5B1) in archive libGEN_TARGET.a
```

I think this is happening because the dynamic `executorch.so` includes
the static `GEN_TARGET.a` as `--whole-archive`, exporting GEN_TARGET's
statically-linked symbols as dynamic.

We don't need to define this for all target environments, but the
current CMake setup doesn't give us a way to check the target OS when we
want it.

Test Plan:

```
mkdir cmake-build
cd cmake-build
CC=`which clang` CXX=`which clang++` cmake ..
make

...

Built target executorch
```