### PR TITLE
Remove undefined behavior from ExecutorTest.ArrayRef

### DIFF
--- a/test/test_executor.cpp
+++ b/test/test_executor.cpp
@@ -325,13 +325,24 @@ TEST(ExecutorTest, Registry) {
   ASSERT_EQ(d_ptr[3], 12);
 }
 
-TEST(ExecutorTest, ArrayRef) {
-  IntArrayRef foo(1);
-  ASSERT_EQ(foo[0], 1);
-  int64_t* bar = new int64_t[1];
-  size_t length = 1;
-  IntArrayRef bap(bar, length);
-  ASSERT_EQ(sizeof(bap), 16);
+TEST(ExecutorTest, IntArrayRefSingleElement) {
+  // Create an IntArrayRef with a single element. `ref` will contain a pointer
+  // to `one`, which must outlive the array ref.
+  const IntArrayRef::value_type one = 1;
+  IntArrayRef ref(one);
+  EXPECT_EQ(ref[0], 1);
+}
+
+TEST(ExecutorTest, IntArrayRefDataAndLength) {
+  // Create an IntArrayRef from an array. `ref` will contain a pointer to
+  // `array`, which must outlive the array ref.
+  const IntArrayRef::value_type array[4] = {5, 6, 7, 8};
+  const IntArrayRef::size_type length = 4;
+  IntArrayRef ref(array, length);
+
+  EXPECT_EQ(ref.size(), length);
+  EXPECT_EQ(ref.front(), 5);
+  EXPECT_EQ(ref.back(), 8);
 }
 
 TEST(ExecutorTest, Execute) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #42
* #41
* #40

This test was causing ArrayRef to take the address of a literal `1`
passed into the ctor. It happened to work on macOS+clang, but failed
on Linux.

Also fix a memory leak and unnecessary allocation in the buffer + length
test, and add behavioral tests instead of checking the size of the
object. If we did want to check the size of the object we could use
static_assert(), but that check would fail for 32-bit targets.

Test Plan:
Ran test_executor on Linux; new tests pass. Also passes on macOS.

```
executorch/cmake-build$ ./test/test_executor

[==========] Running 12 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 12 tests from ExecutorTest
[ RUN      ] ExecutorTest.Tensor
[       OK ] ExecutorTest.Tensor (0 ms)
[ RUN      ] ExecutorTest.EValue
[       OK ] ExecutorTest.EValue (0 ms)
[ RUN      ] ExecutorTest.Serialize
[       OK ] ExecutorTest.Serialize (0 ms)
[ RUN      ] ExecutorTest.load
[       OK ] ExecutorTest.load (0 ms)
[ RUN      ] ExecutorTest.Registry
[       OK ] ExecutorTest.Registry (0 ms)
[ RUN      ] ExecutorTest.IntArrayRefSingleElement
[       OK ] ExecutorTest.IntArrayRefSingleElement (0 ms)
[ RUN      ] ExecutorTest.IntArrayRefDataAndLength
[       OK ] ExecutorTest.IntArrayRefDataAndLength (0 ms)
[ RUN      ] ExecutorTest.Execute
[       OK ] ExecutorTest.Execute (0 ms)
[ RUN      ] ExecutorTest.EValueFromScalar
[       OK ] ExecutorTest.EValueFromScalar (0 ms)
[ RUN      ] ExecutorTest.EValueToScalar
[       OK ] ExecutorTest.EValueToScalar (0 ms)
[ RUN      ] ExecutorTest.OpRegistration
[       OK ] ExecutorTest.OpRegistration (0 ms)
[ RUN      ] ExecutorTest.OpRegistrationAddMul
[       OK ] ExecutorTest.OpRegistrationAddMul (0 ms)
[----------] 12 tests from ExecutorTest (0 ms total)

[----------] Global test environment tear-down
[==========] 12 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 12 tests.
```