### PR TITLE
Fixes to compile for embedded targets

### DIFF
--- a/core/error_message.cpp
+++ b/core/error_message.cpp
@@ -10,8 +10,13 @@ void error_with_message(const char* message) {
   // A hacky error function before we have a good convention,
   // better without exception.
   printf("%s\n", message);
+#if defined(__linux__) || defined(__APPLE__)
   throw std::runtime_error(message);
-  // exit(1); // this line doesnt actually cause tests to fail so switched to the above for now.
+#else
+  // Exception handling is disabled on embedded targets so we use this workaround
+  // for now until error handling is improved.
+  exit(1);
+#endif
 }
 } // namespace executor
 } // namespace torch

--- a/core/tensor.h
+++ b/core/tensor.h
@@ -72,7 +72,7 @@ class Tensor {
     void* data = nullptr;
 
     Tensor() {}
-    Tensor(ScalarType type, int dim, int* sizes, void* data=nullptr, int* strides = nullptr, int storage_offset = 0)
+    Tensor(ScalarType type, int32_t dim, int32_t* sizes, void* data=nullptr, int32_t* strides = nullptr, int32_t storage_offset = 0)
     : dim_(dim), sizes_(sizes, dim), type_(type), data(data), strides_(strides), storage_offset_(storage_offset)
     {
       if (!data) {
@@ -86,15 +86,15 @@ class Tensor {
       return nbytes_;
     }
 
-    int size(int dim) const {
+    int32_t size(int32_t dim) const {
       return sizes_[dim];
     }
 
-    int dim() const {
+    int32_t dim() const {
       return dim_;
     }
 
-    int numel() const {
+    int32_t numel() const {
       return numel_;
     }
 
@@ -103,31 +103,31 @@ class Tensor {
     }
 
     // Return the size of one element of the tensor
-    int element_size() const{
+    int32_t element_size() const{
       return scalarTypeItemSizes[static_cast<int>(type_)];
     }
 
-    int storage_offset() const {
+    int32_t storage_offset() const {
       return storage_offset_;
     }
 
-    ArrayRef<int> sizes() {
+    ArrayRef<int32_t> sizes() {
       return sizes_;
     }
 
-    const ArrayRef<int> sizes() const {
+    const ArrayRef<int32_t> sizes() const {
       return sizes_;
     }
 
   private:
 
     ScalarType type_;
-    int dim_ = 0;
-    int nbytes_ = 0;
-    int storage_offset_ = 0;
-    ArrayRef<int> sizes_;
-    int* strides_ = nullptr;
-    int numel_ = 0;
+    int32_t dim_ = 0;
+    int32_t nbytes_ = 0;
+    int32_t storage_offset_ = 0;
+    ArrayRef<int32_t> sizes_;
+    int32_t* strides_ = nullptr;
+    int32_t numel_ = 0;
 
     /**
     * Compute the number of elements based on the sizes of a tensor.

--- a/executor.cpp
+++ b/executor.cpp
@@ -58,7 +58,7 @@ int ExecutionPlan::init(executorch::ExecutionPlan* s_plan) {
       Tensor *t = new Tensor(
           static_cast<ScalarType>(s_tensor->scalar_type()),
           s_tensor->sizes()->size(),
-          const_cast<int *>(
+          const_cast<int32_t *>(
               s_tensor->sizes()->data()),
           nullptr,
           nullptr,
@@ -84,7 +84,7 @@ int ExecutionPlan::init(executorch::ExecutionPlan* s_plan) {
       for (auto s_tensor = s_tensor_list->begin(); s_tensor != s_tensor_list->end(); s_tensor_list++)  {
         executor_tensors.emplace_back(static_cast<ScalarType>(s_tensor->scalar_type()),
           s_tensor->sizes()->size(),
-          const_cast<int *>(
+          const_cast<int32_t *>(
               s_tensor->sizes()->data()),
           nullptr,
           nullptr,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #54
* __->__ #53
* #52

Summary:
This PR has a couple of fixes to enable compilation for embedded targets:
- Transition int => int32_t in tensor.h and executor.cpp to be consitent with the
flatbuffers generated schema, otherwise when compiling for ARM embedded targets the
compiler complains about invalid 'const_cast' from type 'const long int*' to type 'int*'
- Use exit when compiling for embedded targets instead of throwing an exception as
exception handling is disabled on embedded targets.

Test Plan:
Compiled and ran tests.