### PR TITLE
Adding support to compile for ethos target platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,15 @@ include(ExternalProject)
 
 cmake_minimum_required(VERSION 3.14)
 #set(CMAKE_VERBOSE_MAKEFILE 1)
-include(codegen/Codegen.cmake)
+
+set(EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+if("${TARGET_PLATFORM}" STREQUAL "ethos")
+    set(TARGET_CPU "cortex-m55" CACHE STRING "Target CPU")
+    set(CMAKE_TOOLCHAIN_FILE
+        ${EXECUTORCH_SOURCE_DIR}/toolchains/arm-none-eabi-gcc.cmake)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Setting build type to Release, for debug builds use"
     "'-DCMAKE_BUILD_TYPE=Debug'.")
@@ -18,12 +26,12 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(EXECUTORCH_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
-
 # Executorch project
 project(Executorch
     DESCRIPTION "Simple and portable executor of PyTorch programs"
     VERSION 1.0.1)
+
+include(codegen/Codegen.cmake)
 
 # Check submodule
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/flatbuffers/CMakeLists.txt" OR NOT EXISTS "${PROJECT_SOURCE_DIR}/googletest/CMakeLists.txt")
@@ -75,8 +83,6 @@ add_library(executorch SHARED
     ${EXECUTORCH_SOURCE_DIR}/core/operator_registry.cpp
     ${EXECUTORCH_SOURCE_DIR}/kernels/demo_operator_kernels.cpp
 )
-
-add_dependencies(executorch schema_header)
 
 if(APPLE)
   set(link_flag_1 "-Wl,-all_load")

--- a/toolchains/arm-none-eabi-gcc.cmake
+++ b/toolchains/arm-none-eabi-gcc.cmake
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set(TARGET_CPU "cortex-m4" CACHE STRING "Target CPU")
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_CXX_COMPILER "arm-none-eabi-g++")
+
+# Convert TARGET_CPU=Cortex-M33+nofp+nodsp into
+#   - CMAKE_SYSTEM_PROCESSOR=cortex-m33
+#   - TARGET_CPU_FEATURES=no-fp;no-dsp
+string(REPLACE "+" ";" TARGET_CPU_FEATURES ${TARGET_CPU})
+list(POP_FRONT TARGET_CPU_FEATURES CMAKE_SYSTEM_PROCESSOR)
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} CMAKE_SYSTEM_PROCESSOR)
+
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Select C/C++ version
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+
+# Compile options
+add_compile_options(
+    -mcpu=${TARGET_CPU}
+    -mthumb
+    "$<$<CONFIG:DEBUG>:-gdwarf-3>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-unwind-tables;-fno-rtti;-fno-exceptions>")
+
+# Compile defines
+add_compile_definitions(
+    "$<$<NOT:$<CONFIG:DEBUG>>:NDEBUG>")
+
+# Link options
+add_link_options(
+    -mcpu=${TARGET_CPU}
+    -mthumb
+    --specs=nosys.specs)
+
+# Set floating point unit
+if("${TARGET_CPU}" MATCHES "\\+fp")
+    set(FLOAT hard)
+elseif("${TARGET_CPU}" MATCHES "\\+nofp")
+    set(FLOAT soft)
+elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "cortex-m33" OR
+       "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "cortex-m55")
+    set(FLOAT hard)
+elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "cortex-m4" OR
+        "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "cortex-m7")
+    set(FLOAT hard)
+    set(FPU_CONFIG "fpv4-sp-d16")
+    add_compile_options(-mfpu=${FPU_CONFIG})
+    add_link_options(-mfpu=${FPU_CONFIG})
+else()
+    set(FLOAT soft)
+endif()
+
+if (FLOAT)
+    add_compile_options(-mfloat-abi=${FLOAT})
+    add_link_options(-mfloat-abi=${FLOAT})
+endif()
+
+# Compilation warnings
+add_compile_options(
+    -Wall
+    -Wextra
+
+    -Wcast-align
+    -Wdouble-promotion
+    -Wformat
+    -Wmissing-field-initializers
+    -Wnull-dereference
+    -Wredundant-decls
+    -Wshadow
+    -Wswitch
+    -Wswitch-default
+    -Wunused
+
+    -Wno-redundant-decls
+)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #54
* #53
* #52

Summary:
- Added arm-none-eabi-gcc.cmake obtained from ARM's ethos-u-core-platform repo
- Added support to compile executorch target for ethos platform using commands
descirbed in the test plan.

Test Plan:
mkdir build
cd build
cmake -DTARGET_PLATFORM=ethos ..
make -j executorch